### PR TITLE
[PR] acces token Set-Cookie 기능 추가

### DIFF
--- a/src/main/java/com/example/codebase/controller/AuthController.java
+++ b/src/main/java/com/example/codebase/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.example.codebase.controller;
 
+import static com.example.codebase.util.SecurityUtil.getCookieAccessTokenValue;
+
 import com.example.codebase.domain.auth.dto.LoginDTO;
 import com.example.codebase.domain.auth.dto.TokenResponseDTO;
 import com.example.codebase.domain.auth.service.AuthService;
@@ -33,7 +35,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity login(@Valid @RequestBody LoginDTO loginDTO) {
         TokenResponseDTO responseDTO = tokenProvider.generateToken(loginDTO);
-        return new ResponseEntity(responseDTO, HttpStatus.OK);
+
+        // Set Cookie
+        return ResponseEntity.ok()
+                .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
+                .body(responseDTO);
     }
 
     @ApiOperation(value = "로그아웃", notes = "해당 사용자의 리프레시 토큰을 서버에서 삭제합니다.")
@@ -49,7 +55,9 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity refresh(@RequestBody String refreshToken) {
         TokenResponseDTO responseDTO = tokenProvider.regenerateToken(refreshToken);
-        return new ResponseEntity(responseDTO, HttpStatus.OK);
+        return ResponseEntity.ok()
+                .header("Set-Cookie", getCookieAccessTokenValue(responseDTO))
+                .body(responseDTO);
     }
 
     @ApiOperation(value = "이메일 인증확인 API", notes = "인증코드를 기반으로 이메일 인증 처리")

--- a/src/main/java/com/example/codebase/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/codebase/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,8 +1,11 @@
 package com.example.codebase.domain.auth.handler;
 
+import static com.example.codebase.util.SecurityUtil.getCookieAccessTokenValue;
+
 import com.example.codebase.domain.auth.dto.TokenResponseDTO;
 import com.example.codebase.filter.JwtFilter;
 import com.example.codebase.jwt.TokenProvider;
+import javax.servlet.http.Cookie;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +53,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
             if (authentication.getAuthorities().contains("ROLE_GUEST") ){ // 최초 가입한 사람 -> ROLE_GUEST
                 response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + token.getRefreshToken());
+                response.addCookie(new Cookie("access-token", getCookieAccessTokenValue(token)));
                 response.sendRedirect("oauth2/sign-up"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
             }
             else {

--- a/src/main/java/com/example/codebase/util/SecurityUtil.java
+++ b/src/main/java/com/example/codebase/util/SecurityUtil.java
@@ -1,6 +1,7 @@
 package com.example.codebase.util;
 
 
+import com.example.codebase.domain.auth.dto.TokenResponseDTO;
 import com.example.codebase.domain.member.dto.AuthorityDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -82,6 +83,16 @@ public class SecurityUtil {
      */
     public static Boolean isAdminOrSameUser(String username){
         return isAdmin() || isSameUser(username, getCurrentUsername().get()) ? true : false;
+    }
+
+    public static String getCookieAccessTokenValue(TokenResponseDTO tokenDto) {
+        StringBuilder sb = new StringBuilder("access-token=");
+        // TODO : Domain 설정
+        sb.append(tokenDto.getAccessToken());
+        sb.append("; Path=/; Max-Age=");
+        sb.append(tokenDto.getExpiresIn());
+        sb.append("; HttpOnly; Secure");
+        return sb.toString();
     }
 
 }

--- a/src/test/java/com/example/codebase/controller/ArtworkControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/ArtworkControllerTest.java
@@ -64,7 +64,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Transactional @Slf4j
+@Transactional
+@Slf4j
 class ArtworkControllerTest {
 
     @Autowired
@@ -158,7 +159,8 @@ class ArtworkControllerTest {
 
         List<ArtworkMedia> artworkMediaList = new ArrayList<>();
         for (int i = 0; i < mediaSize; i++) {
-            MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg", createImageFile());
+            MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg",
+                    createImageFile());
             String url = s3Service.saveUploadFile(mockMultipartFile);
 
             ArtworkMedia artworkMedia = ArtworkMedia.builder()
@@ -225,10 +227,12 @@ class ArtworkControllerTest {
         dto.setThumbnail(thumbnailCreateDTO);
         dto.setMedias(Collections.singletonList(mediaCreateDTO));
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg",
+                createImageFile());
         mediaFiles.add(mockMultipartFile);
 
         mockMvc.perform(
@@ -274,11 +278,14 @@ class ArtworkControllerTest {
         dto.setThumbnail(thumbnailCreateDTO);
         dto.setMedias(mediaCreateDTOList);
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "url", "text/plane", "https://www.youtube.com/watch?v=95YLHDzsg8A".getBytes());
-        MockMultipartFile mockMultipartFile2 = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "url", "text/plane",
+                "https://www.youtube.com/watch?v=95YLHDzsg8A".getBytes());
+        MockMultipartFile mockMultipartFile2 = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg",
+                createImageFile());
         mediaFiles.add(mockMultipartFile1);
         mediaFiles.add(mockMultipartFile2);
 
@@ -321,10 +328,12 @@ class ArtworkControllerTest {
         dto.setThumbnail(thumbnailCreateDTO);
         dto.setMedias(mediaCreateDTOList);
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "image.jpg", "text/plain", "https://youtu.be/95YLHDzsg8A?t=153".getBytes());
+        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "image.jpg", "text/plain",
+                "https://youtu.be/95YLHDzsg8A?t=153".getBytes());
         mediaFiles.add(mockMultipartFile1);
 
         mockMvc.perform(
@@ -344,7 +353,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("아트워크 URL 유튜브 주소가 아닐 시")
     @Test
-    public void 아트워크_URL_등록_유튜브아닐시 () throws Exception {
+    public void 아트워크_URL_등록_유튜브아닐시() throws Exception {
         createOrLoadMember();
 
         ArtworkMediaCreateDTO thumbnailCreateDTO = new ArtworkMediaCreateDTO();
@@ -365,10 +374,12 @@ class ArtworkControllerTest {
         dto.setThumbnail(thumbnailCreateDTO);
         dto.setMedias(mediaCreateDTOList);
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "url", "text/plane", "https://www.youtube.com".getBytes());
+        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "url", "text/plane",
+                "https://www.youtube.com".getBytes());
         mediaFiles.add(mockMultipartFile1);
 
         mockMvc.perform(
@@ -379,7 +390,6 @@ class ArtworkControllerTest {
                                 .contentType(MediaType.MULTIPART_FORM_DATA)
                                 .accept(MediaType.APPLICATION_JSON)
                                 .characterEncoding("UTF-8")
-
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest());
@@ -407,11 +417,14 @@ class ArtworkControllerTest {
         mediaCreateDTO2.setDescription("미디어 설명2");
         mediaCreateDTOList.add(mediaCreateDTO2);
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "image1.jpg", "image/jpg", createImageFile());
-        MockMultipartFile mockMultipartFile2 = new MockMultipartFile("mediaFiles", "image2.jpg", "image/jpg", createImageFile());
+        MockMultipartFile mockMultipartFile1 = new MockMultipartFile("mediaFiles", "image1.jpg", "image/jpg",
+                createImageFile());
+        MockMultipartFile mockMultipartFile2 = new MockMultipartFile("mediaFiles", "image2.jpg", "image/jpg",
+                createImageFile());
 
         mediaFiles.add(mockMultipartFile1);
         mediaFiles.add(mockMultipartFile2);
@@ -483,7 +496,8 @@ class ArtworkControllerTest {
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
         mediaFiles.add(new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg", "test".getBytes()));
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         ArtworkCreateDTO dto = new ArtworkCreateDTO();
         dto.setTitle("아트워크_테스트");
@@ -556,9 +570,9 @@ class ArtworkControllerTest {
         dto.setMediaUrl("수정한 URL");
         dto.setDescription("수정한 설명");
 
-
         mockMvc.perform(
-                        put(String.format("/api/artworks/%d/media/%d", artwork.getId(), artwork.getArtworkMedia().get(0).getId()))
+                        put(String.format("/api/artworks/%d/media/%d", artwork.getId(),
+                                artwork.getArtworkMedia().get(0).getId()))
                                 .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(dto))
                 )
@@ -610,10 +624,12 @@ class ArtworkControllerTest {
         dto.setThumbnail(thumbnailCreateDTO);
 
         List<MockMultipartFile> mediaFiles = new ArrayList<>();
-        MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("mediaFiles", "image.jpg", "image/jpg",
+                createImageFile());
         mediaFiles.add(mockMultipartFile);
 
-        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg", createImageFile());
+        MockMultipartFile thumbnailFile = new MockMultipartFile("thumbnailFile", "image.jpg", "image/jpg",
+                createImageFile());
 
         mockMvc.perform(
                         multipart("/api/artworks")
@@ -655,7 +671,6 @@ class ArtworkControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk());
     }
-
 
 
     @WithMockCustomUser(username = "admin", role = "ADMIN")
@@ -791,7 +806,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("전체 아트워크 조회 시 좋아요 여부와 함께 조회")
     @Test
-    public void 좋아요_여부_와_전체_아트워크 () throws Exception {
+    public void 좋아요_여부_와_전체_아트워크() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, true);
 
@@ -814,7 +829,7 @@ class ArtworkControllerTest {
 
     @DisplayName("비회원이 전체 아트워크 조회 시 좋아요 여부와 함께 조회")
     @Test
-    public void 비회원_좋아요_여부_와_전체_아트워크 () throws Exception {
+    public void 비회원_좋아요_여부_와_전체_아트워크() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, true);
 
@@ -832,7 +847,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("단일 아트워크 조회 시 좋아요 여부와 함께 조회")
     @Test
-    public void 좋아요_여부_와_단일_아트워크 () throws Exception {
+    public void 좋아요_여부_와_단일_아트워크() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, true);
 
@@ -864,7 +879,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("특정 아트워크 조회 시 로그인한 사용자의 좋아요 여부와 함께 조회")
     @Test
-    public void 로그인사용자의_좋아요_여부_와_특정_아트워크 () throws Exception {
+    public void 로그인사용자의_좋아요_여부_와_특정_아트워크() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, true);
 
@@ -894,11 +909,10 @@ class ArtworkControllerTest {
 
     @DisplayName("비회원이 단일 아트워크 조회 시 좋아요 여부와 함께 조회")
     @Test
-    public void 비회원_좋아요_여부_와_단일_아트워크 () throws Exception {
+    public void 비회원_좋아요_여부_와_단일_아트워크() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
 
         String username = artwork1.getMember().getUsername();
-
 
         // 좋아요 표시한 사용자들 조회
         mockMvc.perform(
@@ -910,7 +924,7 @@ class ArtworkControllerTest {
 
     @DisplayName("아트워크 작품명, 태그명, 작가명으로 각각 검색 시")
     @Test
-    public void 아트워크_검색 () throws Exception {
+    public void 아트워크_검색() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, true);
 
@@ -940,7 +954,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("비공개 아트워크를 내 프로필 API로 조회 시 ")
     @Test
-    public void 비공개_아트워크_내_프로필조회 () throws Exception {
+    public void 비공개_아트워크_내_프로필조회() throws Exception {
         Artwork artwork = createOrLoadArtwork(1, false);
 
         mockMvc.perform(
@@ -953,7 +967,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "ADMIN")
     @DisplayName("관리자가 아트워크 전체 조회 시 공개여부와 상관없이 조회")
     @Test
-    public void 관리자_전체_조회_시 () throws Exception {
+    public void 관리자_전체_조회_시() throws Exception {
         Artwork artwork1 = createOrLoadArtwork(1, true);
         Artwork artwork2 = createOrLoadArtwork(2, false);
 
@@ -967,16 +981,16 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("아트워크 댓글 생성 시")
     @Test
-    public void 아트워크_댓글_생성_시 () throws Exception {
+    public void 아트워크_댓글_생성_시() throws Exception {
         Artwork artwork = createOrLoadArtwork();
         ArtworkCommentCreateDTO commentCreateDTO = new ArtworkCommentCreateDTO();
         commentCreateDTO.setContent("댓글 내용");
 
         mockMvc.perform(
-                post("/api/artworks/" + artwork.getId() + "/comments")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentCreateDTO))
-        )
+                        post("/api/artworks/" + artwork.getId() + "/comments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(commentCreateDTO))
+                )
                 .andDo(print())
                 .andExpect(status().isCreated());
     }
@@ -984,7 +998,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("아트워크 댓글 삭제 시")
     @Test
-    public void 아트워크_댓글_삭제_시 () throws Exception {
+    public void 아트워크_댓글_삭제_시() throws Exception {
         Artwork artwork = createArtworkWithComment(5);
         Long commentId = artwork.getArtworkComments().get(0).getId();
 
@@ -998,7 +1012,7 @@ class ArtworkControllerTest {
     @WithMockCustomUser(username = "testid", role = "USER")
     @DisplayName("아트워크 상세 조회 시 댓글도 같이 조회 된다")
     @Test
-    public void 아트워크_상세조회_댓글 () throws Exception {
+    public void 아트워크_상세조회_댓글() throws Exception {
         Artwork artwork = createArtworkWithComment(5);
 
         mockMvc.perform(


### PR DESCRIPTION
- JWT 액세스 토큰 발급 시 응답 Body와 함께 Set-Cookie를 이용해 Cookie에 저장합니다.
- Secure, HttpOnly를 이용해 토큰 탈취 가능성을 줄였습니다.