### PR TITLE
[PR] 대댓글 생성이 안되는 에러 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/post/repository/PostCommentRepository.java
+++ b/src/main/java/com/example/codebase/domain/post/repository/PostCommentRepository.java
@@ -1,10 +1,14 @@
 package com.example.codebase.domain.post.repository;
 
 
+import com.example.codebase.domain.post.entity.Post;
 import com.example.codebase.domain.post.entity.PostComment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+
+    Optional<PostComment> findByIdAndPost(Long id, Post post);
 }
 
 

--- a/src/main/java/com/example/codebase/domain/post/service/PostService.java
+++ b/src/main/java/com/example/codebase/domain/post/service/PostService.java
@@ -169,20 +169,20 @@ public class PostService {
       Long perentId = parentCommentId.get();
       PostComment parentComment =
           postCommentRepository
-              .findById(perentId)
-              .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+              .findByIdAndPost(perentId, post)
+              .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글이거나 해당 게시글에 속해있지 않습니다."));
 
       // 2차 대댓글 일 시
       if (parentComment.getParent() == null) {
         newComment.setParent(parentComment);
         parentComment.addComment(newComment);
-        postCommentRepository.save(parentComment);
+        postCommentRepository.save(newComment);
       } else {
         // 3차 대댓글 일 시
         newComment.setMentionUsername(parentComment.getAuthor().getUsername());
         newComment.setParent(parentComment.getParent());
         parentComment.getParent().addComment(newComment);
-        postCommentRepository.save(parentComment.getParent());
+        postCommentRepository.save(newComment);
       }
     }
     else {


### PR DESCRIPTION
- TransientObjectException: object references an unsaved transient instance - save the transient instance before flushing -> 해결
- 기존 : 새로운 댓글 저장 로직엔 부모 연관관계에 매핑, 추가만 하고 새로운댓글을 저장하는 코드가 없어서 트랜잭션 예외 처리가 발생
- 이후 : 새로운 댓글 저장 로직에 save(newComment) 코드 추가
- 또한 다른 게시글의 댓글을 부모로하는 대댓글 생성 예외처리 적용