### PR TITLE
[PR] Feed 생성 시 Post의 Commets가 일치하지 않는 이슈 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/post/entity/Post.java
+++ b/src/main/java/com/example/codebase/domain/post/entity/Post.java
@@ -89,6 +89,11 @@ public class Post {
         this.comments = this.postComment.size();
     }
 
+    public int getComments() {
+        int comments = this.comments + getAllLevelTwoCommentSize();
+        return comments;
+    }
+
     public int getAllLevelTwoCommentSize() {
         int commentSize = 0;
         for (PostComment postComment : this.postComment) {

--- a/src/main/java/com/example/codebase/domain/post/service/PostService.java
+++ b/src/main/java/com/example/codebase/domain/post/service/PostService.java
@@ -21,212 +21,211 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PostService {
-  private final PostRepository postRepository;
-  private final MemberRepository memberRepository;
-  private final PostLikeMemberRepository postLikeMemberRepository;
-  private final PostCommentRepository postCommentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final PostLikeMemberRepository postLikeMemberRepository;
+    private final PostCommentRepository postCommentRepository;
 
-  @Autowired
-  public PostService(
-      PostRepository postRepository,
-      MemberRepository memberRepository,
-      PostLikeMemberRepository postLikeMemberRepository,
-      PostCommentRepository postCommentRepository) {
-    this.postRepository = postRepository;
-    this.memberRepository = memberRepository;
-    this.postLikeMemberRepository = postLikeMemberRepository;
-    this.postCommentRepository = postCommentRepository;
-  }
-
-  @Transactional
-  public PostResponseDTO createPost(PostCreateDTO postCreateDTO, String loginUsername) {
-    Member author =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    Post newPost = Post.of(postCreateDTO, author);
-    author.addPost(newPost);
-
-    postRepository.save(newPost);
-    return PostResponseDTO.from(newPost);
-  }
-
-  public PostsResponseDTO getPosts(int page, int size, String sortDirection) {
-    Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
-    PageRequest pageRequest = PageRequest.of(page, size, sort);
-
-    Page<Post> posts = postRepository.findAll(pageRequest);
-    PageInfo pageInfo = PageInfo.of(page, size, posts.getTotalPages(), posts.getTotalElements());
-
-    List<PostResponseDTO> dtos =
-        posts.stream().map(PostResponseDTO::from).collect(Collectors.toList());
-    return PostsResponseDTO.of(dtos, pageInfo);
-  }
-
-  @Transactional(readOnly = true)
-  public PostsResponseDTO getPosts(String loginUsername, int page, int size, String sortDirection) {
-    Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
-    PageRequest pageRequest = PageRequest.of(page, size, sort);
-
-    Member member =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    Page<PostWithIsLiked> postPages = postRepository.findAllWithIsLiked(member, pageRequest);
-    PageInfo pageInfo =
-        PageInfo.of(page, size, postPages.getTotalPages(), postPages.getTotalElements());
-
-    List<PostResponseDTO> dtos =
-        postPages.stream().map(PostResponseDTO::from).collect(Collectors.toList());
-    return PostsResponseDTO.of(dtos, pageInfo);
-  }
-
-  @Transactional
-  public PostResponseDTO updatePost(Long postId, PostUpdateDTO postUpdateDTO) {
-    // TODO: 동일 작성자 검증 추가
-    Post post =
-        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
-
-    post.update(postUpdateDTO);
-    return PostResponseDTO.from(post);
-  }
-
-  @Transactional
-  public void deletePost(Long postId) {
-    // TODO: 동일 작성자 검증 추가
-    Post post =
-        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
-
-    postRepository.delete(post);
-  }
-
-  public PostWithLikesResponseDTO getPost(Long postId) {
-    Post post =
-        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
-
-    post.incressView();
-
-    List<PostLikeMemberDTO> postLikeMemberDtos =
-        post.getPostLikeMembers().stream()
-            .map(
-                (PostLikeMember likeMember) ->
-                    PostLikeMemberDTO.of(likeMember.getMember(), likeMember.getLikedTime()))
-            .collect(Collectors.toList());
-
-    return PostWithLikesResponseDTO.create(post, postLikeMemberDtos);
-  }
-
-  // 로그인 유저는 좋아요 여부도 함께 표시
-  public PostWithLikesResponseDTO getPost(String loginUsername, Long postId) {
-    PostWithLikesResponseDTO post = getPost(postId);
-
-    Member member =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    postLikeMemberRepository
-        .findById(PostLikeMemberIds.of(member, post.getId()))
-        .ifPresent((PostLikeMember likeMember) -> post.setIsLiked(true));
-
-    return post;
-  }
-
-  @Transactional
-  public PostResponseDTO likePost(Long postId, String loginUsername) {
-    Post post =
-        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
-
-    Member member =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    Optional<PostLikeMember> likeMember =
-        postLikeMemberRepository.findById(PostLikeMemberIds.of(member, post));
-
-    boolean isLiked = likeMember.isPresent();
-    if (isLiked) {
-      postLikeMemberRepository.delete(likeMember.get());
-    } else {
-      PostLikeMember newLike = PostLikeMember.of(post, member);
-      post.addLikeMember(newLike);
+    @Autowired
+    public PostService(
+            PostRepository postRepository,
+            MemberRepository memberRepository,
+            PostLikeMemberRepository postLikeMemberRepository,
+            PostCommentRepository postCommentRepository) {
+        this.postRepository = postRepository;
+        this.memberRepository = memberRepository;
+        this.postLikeMemberRepository = postLikeMemberRepository;
+        this.postCommentRepository = postCommentRepository;
     }
 
-    Integer likeCount = postLikeMemberRepository.countByPostId(post.getId());
-    post.setLikes(likeCount);
+    @Transactional
+    public PostResponseDTO createPost(PostCreateDTO postCreateDTO, String loginUsername) {
+        Member author =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
 
-    return PostResponseDTO.of(post, !isLiked);
-  }
+        Post newPost = Post.of(postCreateDTO, author);
+        author.addPost(newPost);
 
-  @Transactional
-  public PostResponseDTO createComment(
-      Long postId, PostCommentCreateDTO commentCreateDTO, String loginUsername) {
-    Post post =
-        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
-
-    Member author =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    PostComment newComment = PostComment.of(post, commentCreateDTO, author);
-
-    Optional<Long> parentCommentId = Optional.ofNullable(commentCreateDTO.getParentCommentId());
-    if (parentCommentId.isPresent()) {
-      Long perentId = parentCommentId.get();
-      PostComment parentComment =
-          postCommentRepository
-              .findByIdAndPost(perentId, post)
-              .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글이거나 해당 게시글에 속해있지 않습니다."));
-
-      // 2차 대댓글 일 시
-      if (parentComment.getParent() == null) {
-        newComment.setParent(parentComment);
-        parentComment.addComment(newComment);
-        postCommentRepository.save(newComment);
-      } else {
-        // 3차 대댓글 일 시
-        newComment.setMentionUsername(parentComment.getAuthor().getUsername());
-        newComment.setParent(parentComment.getParent());
-        parentComment.getParent().addComment(newComment);
-        postCommentRepository.save(newComment);
-      }
-    }
-    else {
-      post.addComment(newComment);
-      postRepository.save(post);
+        postRepository.save(newPost);
+        return PostResponseDTO.from(newPost);
     }
 
-    return PostResponseDTO.from(post);
-  }
+    public PostsResponseDTO getPosts(int page, int size, String sortDirection) {
+        Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
+        PageRequest pageRequest = PageRequest.of(page, size, sort);
 
-  @Transactional
-  public PostResponseDTO updateComment(
-      Long commentId, PostCommentUpdateDTO commentUpdateDTO, String loginUsername) {
-    PostComment comment =
-        postCommentRepository
-            .findById(commentId)
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+        Page<Post> posts = postRepository.findAll(pageRequest);
+        PageInfo pageInfo = PageInfo.of(page, size, posts.getTotalPages(), posts.getTotalElements());
 
-    Member author =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    if (!comment.getAuthor().equals(author)) {
-      throw new RuntimeException("댓글 작성자만 수정할 수 있습니다.");
+        List<PostResponseDTO> dtos =
+                posts.stream().map(PostResponseDTO::from).collect(Collectors.toList());
+        return PostsResponseDTO.of(dtos, pageInfo);
     }
 
-    comment.update(commentUpdateDTO);
+    @Transactional(readOnly = true)
+    public PostsResponseDTO getPosts(String loginUsername, int page, int size, String sortDirection) {
+        Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), "createdTime");
+        PageRequest pageRequest = PageRequest.of(page, size, sort);
 
-    return PostResponseDTO.from(comment.getPost());
-  }
+        Member member =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
 
-  @Transactional
-  public void deleteComment(Long commentId, String loginUsername) {
-    PostComment comment =
-        postCommentRepository
-            .findById(commentId)
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+        Page<PostWithIsLiked> postPages = postRepository.findAllWithIsLiked(member, pageRequest);
+        PageInfo pageInfo =
+                PageInfo.of(page, size, postPages.getTotalPages(), postPages.getTotalElements());
 
-    Member author =
-        memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
-
-    if (!comment.getAuthor().equals(author)) {
-      throw new RuntimeException("댓글 작성자만 삭제할 수 있습니다.");
+        List<PostResponseDTO> dtos =
+                postPages.stream().map(PostResponseDTO::from).collect(Collectors.toList());
+        return PostsResponseDTO.of(dtos, pageInfo);
     }
 
-    postCommentRepository.delete(comment);
-  }
+    @Transactional
+    public PostResponseDTO updatePost(Long postId, PostUpdateDTO postUpdateDTO) {
+        // TODO: 동일 작성자 검증 추가
+        Post post =
+                postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        post.update(postUpdateDTO);
+        return PostResponseDTO.from(post);
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        // TODO: 동일 작성자 검증 추가
+        Post post =
+                postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        postRepository.delete(post);
+    }
+
+    public PostWithLikesResponseDTO getPost(Long postId) {
+        Post post =
+                postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        post.incressView();
+
+        List<PostLikeMemberDTO> postLikeMemberDtos =
+                post.getPostLikeMembers().stream()
+                        .map(
+                                (PostLikeMember likeMember) ->
+                                        PostLikeMemberDTO.of(likeMember.getMember(), likeMember.getLikedTime()))
+                        .collect(Collectors.toList());
+
+        return PostWithLikesResponseDTO.create(post, postLikeMemberDtos);
+    }
+
+    // 로그인 유저는 좋아요 여부도 함께 표시
+    public PostWithLikesResponseDTO getPost(String loginUsername, Long postId) {
+        PostWithLikesResponseDTO post = getPost(postId);
+
+        Member member =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
+
+        postLikeMemberRepository
+                .findById(PostLikeMemberIds.of(member, post.getId()))
+                .ifPresent((PostLikeMember likeMember) -> post.setIsLiked(true));
+
+        return post;
+    }
+
+    @Transactional
+    public PostResponseDTO likePost(Long postId, String loginUsername) {
+        Post post =
+                postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        Member member =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
+
+        Optional<PostLikeMember> likeMember =
+                postLikeMemberRepository.findById(PostLikeMemberIds.of(member, post));
+
+        boolean isLiked = likeMember.isPresent();
+        if (isLiked) {
+            postLikeMemberRepository.delete(likeMember.get());
+        } else {
+            PostLikeMember newLike = PostLikeMember.of(post, member);
+            post.addLikeMember(newLike);
+        }
+
+        Integer likeCount = postLikeMemberRepository.countByPostId(post.getId());
+        post.setLikes(likeCount);
+
+        return PostResponseDTO.of(post, !isLiked);
+    }
+
+    @Transactional
+    public PostResponseDTO createComment(
+            Long postId, PostCommentCreateDTO commentCreateDTO, String loginUsername) {
+        Post post =
+                postRepository.findById(postId).orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        Member author =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
+
+        PostComment newComment = PostComment.of(post, commentCreateDTO, author);
+
+        Optional<Long> parentCommentId = Optional.ofNullable(commentCreateDTO.getParentCommentId());
+        if (parentCommentId.isPresent()) {
+            Long perentId = parentCommentId.get();
+            PostComment parentComment =
+                    postCommentRepository
+                            .findByIdAndPost(perentId, post)
+                            .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글이거나 해당 게시글에 속해있지 않습니다."));
+
+            // 2차 대댓글 일 시
+            if (parentComment.getParent() == null) {
+                newComment.setParent(parentComment);
+                parentComment.addComment(newComment);
+                postCommentRepository.save(newComment);
+            } else {
+                // 3차 대댓글 일 시
+                newComment.setMentionUsername(parentComment.getAuthor().getUsername());
+                newComment.setParent(parentComment.getParent());
+                parentComment.getParent().addComment(newComment);
+                postCommentRepository.save(newComment);
+            }
+        } else {
+            post.addComment(newComment);
+            postRepository.save(post);
+        }
+
+        return PostResponseDTO.from(post);
+    }
+
+    @Transactional
+    public PostResponseDTO updateComment(
+            Long commentId, PostCommentUpdateDTO commentUpdateDTO, String loginUsername) {
+        PostComment comment =
+                postCommentRepository
+                        .findById(commentId)
+                        .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+
+        Member author =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
+
+        if (!comment.getAuthor().equals(author)) {
+            throw new RuntimeException("댓글 작성자만 수정할 수 있습니다.");
+        }
+
+        comment.update(commentUpdateDTO);
+
+        return PostResponseDTO.from(comment.getPost());
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, String loginUsername) {
+        PostComment comment =
+                postCommentRepository
+                        .findById(commentId)
+                        .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+
+        Member author =
+                memberRepository.findByUsername(loginUsername).orElseThrow(NotFoundMemberException::new);
+
+        if (!comment.getAuthor().equals(author)) {
+            throw new RuntimeException("댓글 작성자만 삭제할 수 있습니다.");
+        }
+
+        postCommentRepository.delete(comment);
+    }
 }

--- a/src/test/java/com/example/codebase/controller/PostControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/PostControllerTest.java
@@ -392,6 +392,12 @@ class PostControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isCreated());
+
+        mockMvc.perform(
+                        post("/api/feed")
+                )
+                .andDo(print())
+                .andExpect(status().isCreated());
     }
 
     @WithMockCustomUser(username = "admin", role = "ADMIN")


### PR DESCRIPTION
- 이전 : Post Comment가 1차 댓글수만 반환
- 이후 : Post 내부 모든 댓글 수 반환
-  일부 코드가 포맷팅되었습니다.

기존에는 Lombok Getter 인해 자동으로 생성되는 getComments() 를 사용하고 있었지만 오버라이딩하여 1차 댓글 수 + 2차 댓글수를 함께 반환하도록 개선했습니다. 