### PR TITLE
[PR] 댓글 삭제 시 갯수가 불일치하는 현상 해결

### DIFF
--- a/src/main/java/com/example/codebase/controller/PostController.java
+++ b/src/main/java/com/example/codebase/controller/PostController.java
@@ -134,8 +134,8 @@ public class PostController {
     public ResponseEntity deleteComment(@PathVariable Long commentId) {
         String loginUsername = SecurityUtil.getCurrentUsername().orElseThrow(() -> new RuntimeException("로그인이 필요합니다."));
 
-        postService.deleteComment(commentId, loginUsername);
+        PostResponseDTO dto = postService.deleteComment(commentId, loginUsername);
 
-        return new ResponseEntity("댓글이 삭제되었습니다.", HttpStatus.OK);
+        return new ResponseEntity(dto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/codebase/domain/post/entity/Post.java
+++ b/src/main/java/com/example/codebase/domain/post/entity/Post.java
@@ -102,4 +102,8 @@ public class Post {
         return commentSize;
     }
 
+    public void removeComment(PostComment comment, int size) {
+        this.postComment.remove(comment);
+        this.comments = size - 1;
+    }
 }

--- a/src/main/java/com/example/codebase/domain/post/repository/PostCommentRepository.java
+++ b/src/main/java/com/example/codebase/domain/post/repository/PostCommentRepository.java
@@ -5,10 +5,14 @@ import com.example.codebase.domain.post.entity.Post;
 import com.example.codebase.domain.post.entity.PostComment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
 
     Optional<PostComment> findByIdAndPost(Long id, Post post);
+
+    @Query("SELECT COUNT(pc) FROM PostComment pc WHERE pc.post = :post")
+    int countByPost(Post post);
 }
 
 

--- a/src/main/java/com/example/codebase/domain/post/service/PostService.java
+++ b/src/main/java/com/example/codebase/domain/post/service/PostService.java
@@ -213,7 +213,7 @@ public class PostService {
     }
 
     @Transactional
-    public void deleteComment(Long commentId, String loginUsername) {
+    public PostResponseDTO deleteComment(Long commentId, String loginUsername) {
         PostComment comment =
                 postCommentRepository
                         .findById(commentId)
@@ -226,6 +226,10 @@ public class PostService {
             throw new RuntimeException("댓글 작성자만 삭제할 수 있습니다.");
         }
 
-        postCommentRepository.delete(comment);
+        Post post = comment.getPost();
+        int comments = postCommentRepository.countByPost(post);
+        post.removeComment(comment, comments);
+
+        return PostResponseDTO.from(post);
     }
 }

--- a/src/test/java/com/example/codebase/controller/PostControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/PostControllerTest.java
@@ -424,7 +424,7 @@ class PostControllerTest {
     @DisplayName("게시물에 댓글을 삭제할시")
     @Test
     void 게시물_댓글_삭제() throws Exception {
-        Post post = createPostWithComment(1);
+        Post post = createPostWithComment(2);
         PostComment comment = post.getPostComment().get(0);
 
         mockMvc.perform(
@@ -432,5 +432,6 @@ class PostControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isOk());
+
     }
 }


### PR DESCRIPTION
- 댓글 삭제 시 DTO 반환
- 해당 게시글의 댓글 수를 가져오는 쿼리 작성 및 사용
- 부모 엔티티에서 자식 엔티티를 삭제하도록 개선