### PR TITLE
[PR] fix: PostResponseDTO media가 null인 이슈 해결

### DIFF
--- a/src/main/java/com/example/codebase/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/post/dto/PostResponseDTO.java
@@ -29,8 +29,6 @@ public class PostResponseDTO {
 
     protected Integer comments;
 
-    protected String mentionUsername;
-
     @Builder.Default
     protected Boolean isLiked = false;
 
@@ -51,6 +49,33 @@ public class PostResponseDTO {
     protected List<PostCommentResponseDTO> commentPosts;
 
     protected List<PostMediaResponseDTO> medias;
+
+    public PostResponseDTO(Post post) {
+        this.id = post.getId();
+        this.content = post.getContent();
+        this.views = post.getViews();
+        this.likes = post.getLikes();
+        this.comments = post.getComments();
+        this.authorUsername = post.getAuthor().getUsername();
+        this.authorName = post.getAuthor().getName();
+        this.authorDescription = post.getAuthor().getIntroduction();
+        this.authorProfileImageUrl = post.getAuthor().getPicture();
+        this.createdTime = post.getCreatedTime();
+        this.updatedTime = post.getUpdatedTime();
+        this.isLiked = false;
+
+        this.medias = post.getPostMedias().stream()
+                .map(PostMediaResponseDTO::from)
+                .collect(Collectors.toList());
+
+        if (post.getPostComment() != null) {
+            this.commentPosts = post.getPostComment().stream()
+                    .filter(comment -> comment.getParent() == null)
+                    .filter(comment -> comment.getChildComments() != null)
+                    .map(PostCommentResponseDTO::from)
+                    .collect(Collectors.toList());
+        }
+    }
 
     public static PostResponseDTO from(Post post) {
         PostResponseDTO response =

--- a/src/main/java/com/example/codebase/domain/post/dto/PostWithLikesResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/post/dto/PostWithLikesResponseDTO.java
@@ -1,11 +1,10 @@
 package com.example.codebase.domain.post.dto;
 
 import com.example.codebase.domain.post.entity.Post;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,31 +13,15 @@ public class PostWithLikesResponseDTO extends PostResponseDTO {
 
     private List<PostLikeMemberDTO> likeMembers;
 
-    public static PostWithLikesResponseDTO create(Post post, List<PostLikeMemberDTO> likeMembers) {
-        PostResponseDTO postDto = PostResponseDTO.from(post);
-
-        PostWithLikesResponseDTO dto = new PostWithLikesResponseDTO();
-        dto.setId(post.getId());
-        dto.setContent(post.getContent());
-        dto.setViews(post.getViews());
-        dto.setLikes(post.getLikes());
-        dto.setComments(post.getComments());
-        dto.setAuthorUsername(post.getAuthor().getUsername());
-        dto.setAuthorName(post.getAuthor().getName());
-        dto.setAuthorDescription(post.getAuthor().getIntroduction());
-        dto.setAuthorProfileImageUrl(post.getAuthor().getPicture());
-        dto.setCreatedTime(post.getCreatedTime());
-        dto.setUpdatedTime(post.getUpdatedTime());
-        dto.setLikeMembers(likeMembers);
-        dto.setCommentPosts(postDto.getCommentPosts());
-        return dto;
+    public PostWithLikesResponseDTO(Post post) {
+        super(post);
     }
 
-//    public static PostWithLikesResponseDTO create(Post post, List<PostResponseDTO> comments, List<PostLikeMemberDTO> postLikeMemberDtos) {
-//        PostWithLikesResponseDTO dto = create(post);
-//        dto.setCommentPosts(comments);
-//        return dto;
-//    }
+    public static PostWithLikesResponseDTO create(Post post, List<PostLikeMemberDTO> likeMembers) {
+        PostWithLikesResponseDTO dto = new PostWithLikesResponseDTO(post);
+        dto.setLikeMembers(likeMembers);
+        return dto;
+    }
 
     public void setLikeMembers(List<PostLikeMemberDTO> likeMembers) {
         this.likeMembers = likeMembers;


### PR DESCRIPTION
PostWithLikesResponseDTO (Post DTO에 Like 관련 정보가 더해진 DTO)에 media가 포함되지 않는 이슈를 해결했습니다.
- 기존에는 생성자가 아닌 정적 팩토리 메소드 from을 통해서 데이터를 set 했었는데 개선 이후에는 생성자를 통해서 DTO를 세팅하도록 하였습니다.
- Post 를 매개변수로 받는 생성자를 생성했습니다.