### PR TITLE
Feat/csrf protection intercept

### DIFF
--- a/src/main/java/com/example/codebase/config/JwtSecurityConfig.java
+++ b/src/main/java/com/example/codebase/config/JwtSecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
-    private TokenProvider tokenProvider;
+    private final TokenProvider tokenProvider;
 
     public JwtSecurityConfig(TokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;

--- a/src/main/java/com/example/codebase/config/WebMvcConfig.java
+++ b/src/main/java/com/example/codebase/config/WebMvcConfig.java
@@ -2,18 +2,30 @@ package com.example.codebase.config;
 
 import com.example.codebase.filter.MDCLoggingFilter;
 import com.example.codebase.filter.ServletLoggingFilter;
+import com.example.codebase.filter.security.RefererCheckIntercepter;
 import com.example.codebase.util.HTMLCharacterEscapes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final Environment environment; // 운영 환경 정보 가져오기 위한 Environment
+
+    @Autowired
+    public WebMvcConfig(Environment environment) {
+        this.environment = environment;
+    }
 
     @Bean
     public MDCLoggingFilter mdcLoggingFilter() {
@@ -28,6 +40,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(escapingConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RefererCheckIntercepter(environment))
+                .addPathPatterns("/api/**");
     }
 
     @Bean

--- a/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
+++ b/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
@@ -23,7 +23,7 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 public class CustomExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity handleRuntimeException(RuntimeException e) {
-        log.info(e.getCause().toString());
+        log.info(String.valueOf(e.getCause()));
         RestResponse response = new RestResponse(false, e.getMessage(), HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
+++ b/src/main/java/com/example/codebase/controller/advice/CustomExceptionHandler.java
@@ -6,6 +6,8 @@ import com.example.codebase.exception.NotAcceptTypeException;
 import com.example.codebase.exception.NotAccessException;
 import java.io.IOException;
 import java.util.Objects;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -16,10 +18,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
+@Slf4j
 @RestControllerAdvice
 public class CustomExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity handleRuntimeException(RuntimeException e) {
+        log.info(e.getCause().toString());
         RestResponse response = new RestResponse(false, e.getMessage(), HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/example/codebase/filter/security/RefererCheckIntercepter.java
+++ b/src/main/java/com/example/codebase/filter/security/RefererCheckIntercepter.java
@@ -1,0 +1,38 @@
+package com.example.codebase.filter.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+
+@Slf4j
+public class RefererCheckIntercepter implements HandlerInterceptor {
+
+    private final Environment environment;
+
+    public RefererCheckIntercepter(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String referer = request.getHeader("Referer");
+        String host = request.getHeader("Host");
+
+        // 운영 환경이 아니면 referer 체크하지 않음
+        if (!Arrays.asList(environment.getActiveProfiles()).contains("prod")) {
+            return true;
+        }
+
+        // referer가 없거나, host와 다르면 차단
+        if (referer == null || !referer.contains(host)) {
+            log.info("유효하지 않은 Referer 요청 referer={}, host={}", referer, host);
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
CSRF 취약점 방어를 위한 Referer 검증 인터셉터를 추가했습니다.

기존에는 JWT 토큰을 사용했기 때문에 Spring Security의 csrf 방어 기능을 비활성화 했습니다. 하지만 JWT 토큰을 Cookie에 담아 보내고 있으므로 csrf 취약점에 노출될 가능성이 있어 코드 수준에서 적절한 방어 코드를 추가했습니다.

추가적으로 운영 환경에서만 CSRF 보호 Intercept가 작동합니다
그리고 Interceptor가 작동하는 path는 /api/** 입니다.