### PR TITLE
Fix/exhibition 조회 안되는 문제

### DIFF
--- a/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleCreateDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleCreateDTO.java
@@ -1,21 +1,19 @@
 package com.example.codebase.domain.exhibition.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 @Getter
 @Setter
 public class EventScheduleCreateDTO {
 
-    @NotBlank(message = "시작시간은 필수입니다.")
+    @NotNull(message = "시작시간은 필수입니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime startDateTime;
@@ -24,7 +22,7 @@ public class EventScheduleCreateDTO {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime endDateTime;
 
-    @NotBlank(message = "장소는 필수입니다.")
+    @NotNull(message = "장소는 필수입니다.")
     private Long locationId;
 
     private String detailLocation;

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleCreateDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleCreateDTO.java
@@ -1,6 +1,7 @@
 package com.example.codebase.domain.exhibition.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,7 +14,7 @@ import java.util.List;
 @Setter
 public class EventScheduleCreateDTO {
 
-    @NotNull(message = "시작시간은 필수입니다.")
+    @NotBlank(message = "시작시간은 필수입니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime startDateTime;

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/EventScheduleResponseDTO.java
@@ -26,12 +26,12 @@ public class EventScheduleResponseDTO {
 
     private List<ParticipantInformationResponseDTO> participants;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDateTime;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endDateTime;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionDetailResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionDetailResponseDTO.java
@@ -22,7 +22,11 @@ public class ExhibitionDetailResponseDTO {
 
     private String title;
 
-    private String author;
+    private String authorName;
+
+    private String authorUserName;
+
+    private String authorProfileImage;
 
     private String description;
 
@@ -70,7 +74,9 @@ public class ExhibitionDetailResponseDTO {
         return ExhibitionDetailResponseDTO.builder()
                 .id(exhibition.getId())
                 .title(exhibition.getTitle())
-                .author(exhibition.getMember().getName())
+                .authorName(exhibition.getMember().getName())
+                .authorUserName(exhibition.getMember().getUsername())
+                .authorProfileImage(exhibition.getMember().getPicture())
                 .description(exhibition.getDescription())
                 .thumbnail(thumbnail)
                 .medias(exhibitionMediaResponseDTOS)

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionSearchDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionSearchDTO.java
@@ -1,11 +1,13 @@
 package com.example.codebase.domain.exhibition.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Setter
@@ -16,18 +18,29 @@ public class ExhibitionSearchDTO {
 
     @Builder.Default
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime startDateTime = LocalDateTime.of(1900, 1, 1, 0, 0);
+    private LocalDate startDate = LocalDate.of(1900, 1, 1);
 
     @Builder.Default
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime endDateTime = LocalDateTime.of(2100, 12, 31, 23, 59);
+    private LocalDate endDate = LocalDate.of(2100, 12, 31);
 
     @NotNull
     private String eventType;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private LocalDateTime startDateTime;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private LocalDateTime endDateTime;
 
     public void repeatTimeValidity() {
         if (this.startDateTime.isAfter(this.endDateTime)) {
             throw new RuntimeException("시작일은 종료일보다 이전에 있어야 합니다.");
         }
+    }
+
+    public void changeTimeFormat() {
+        this.startDateTime = this.startDate.atStartOfDay();
+        this.endDateTime = LocalDateTime.of(this.endDate, LocalTime.MAX);
     }
 }

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionSearchDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/ExhibitionSearchDTO.java
@@ -1,10 +1,11 @@
 package com.example.codebase.domain.exhibition.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -27,10 +28,10 @@ public class ExhibitionSearchDTO {
     @NotNull
     private String eventType;
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonIgnore
     private LocalDateTime startDateTime;
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonIgnore
     private LocalDateTime endDateTime;
 
     public void repeatTimeValidity() {
@@ -39,8 +40,14 @@ public class ExhibitionSearchDTO {
         }
     }
 
-    public void changeTimeFormat() {
-        this.startDateTime = this.startDate.atStartOfDay();
-        this.endDateTime = LocalDateTime.of(this.endDate, LocalTime.MAX);
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+        this.startDateTime = startDate.atStartOfDay();
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+        this.endDateTime = LocalDateTime.of(endDate, LocalTime.MAX);
     }
 }

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/ParticipantInformationDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/ParticipantInformationDTO.java
@@ -10,6 +10,12 @@ public class ParticipantInformationDTO {
     private String username;
 
     private String name;
+
+    public void checkParticipantValidity() {
+        if(this.username != null && this.name != null) {
+            throw new RuntimeException("참가자 정보는 username과 name 둘 중 하나만 존재해야 합니다.");
+        }
+    }
 }
 
 

--- a/src/main/java/com/example/codebase/domain/exhibition/dto/ParticipantInformationResponseDTO.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/dto/ParticipantInformationResponseDTO.java
@@ -14,13 +14,18 @@ public class ParticipantInformationResponseDTO {
 
     private String name;
 
-    // TODO : 뭐가 더 필요하지..
-
     public static ParticipantInformationResponseDTO from(
-        ExhibitionParticipant exhibitionParticipant) {
+            ExhibitionParticipant exhibitionParticipant) {
+        String username = null;
+        if (exhibitionParticipant.getMember() != null) {
+            username = exhibitionParticipant.getMember().getUsername();
+        }
+
+        String name = exhibitionParticipant.getName();
+
         return ParticipantInformationResponseDTO.builder()
-            .username(exhibitionParticipant.getMember().getUsername())
-            .name(exhibitionParticipant.getName())
-            .build();
+                .username(username)
+                .name(name)
+                .build();
     }
 }

--- a/src/main/java/com/example/codebase/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/service/ExhibitionService.java
@@ -129,14 +129,13 @@ public class ExhibitionService {
             participant.checkParticipantValidity();
             ExhibitionParticipant exhibitionParticipant = new ExhibitionParticipant();
 
-            if (participant.getUsername() != null ) {
+            if (participant.getUsername() != null) {
                 Member participantMember =
                         memberRepository
                                 .findByUsername(participant.getUsername())
                                 .orElseThrow(NotFoundMemberException::new);
                 exhibitionParticipant.setMember(participantMember);
-            }
-            else{
+            } else {
                 exhibitionParticipant.setName(participant.getName());
             }
             exhibitionParticipant.setEventSchedule(eventSchedule);
@@ -148,7 +147,6 @@ public class ExhibitionService {
     public ExhibitionPageInfoResponseDTO getAllExhibition(
             ExhibitionSearchDTO exhibitionSearchDTO, int page, int size, String sortDirection) {
 
-        exhibitionSearchDTO.changeTimeFormat();
         exhibitionSearchDTO.repeatTimeValidity();
 
         Sort sort = Sort.by(Direction.fromString(sortDirection), "createdTime");

--- a/src/main/java/com/example/codebase/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/example/codebase/domain/exhibition/service/ExhibitionService.java
@@ -121,29 +121,34 @@ public class ExhibitionService {
         eventSchedule.setLocation(location);
         eventSchedule.setEvent(exhibition);
 
+        eventScheduleRepository.save(eventSchedule);
+
         List<ParticipantInformationDTO> participants =
                 schedule.getParticipants() != null ? schedule.getParticipants() : Collections.emptyList();
         for (ParticipantInformationDTO participant : participants) {
+            participant.checkParticipantValidity();
             ExhibitionParticipant exhibitionParticipant = new ExhibitionParticipant();
 
-            if (participant.getUsername() != null) {
+            if (participant.getUsername() != null ) {
                 Member participantMember =
                         memberRepository
                                 .findByUsername(participant.getUsername())
                                 .orElseThrow(NotFoundMemberException::new);
                 exhibitionParticipant.setMember(participantMember);
             }
+            else{
+                exhibitionParticipant.setName(participant.getName());
+            }
             exhibitionParticipant.setEventSchedule(eventSchedule);
             exhibitionParticipantRepository.save(exhibitionParticipant);
         }
-
-        eventScheduleRepository.save(eventSchedule);
     }
 
     @Transactional(readOnly = true)
     public ExhibitionPageInfoResponseDTO getAllExhibition(
             ExhibitionSearchDTO exhibitionSearchDTO, int page, int size, String sortDirection) {
 
+        exhibitionSearchDTO.changeTimeFormat();
         exhibitionSearchDTO.repeatTimeValidity();
 
         Sort sort = Sort.by(Direction.fromString(sortDirection), "createdTime");

--- a/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
@@ -191,7 +191,7 @@ class ExhibitionControllerTest {
         locationRepository.save(location);
 
         for (int i = 0; i < scheduleSize; i++) {
-            LocalDateTime defaultStartDateTime = LocalDateTime.of(2023, 10, 20, 10, 0); // October 20, 2023 at 10:00 AM
+            LocalDateTime defaultStartDateTime = LocalDateTime.now(); // TODO : 테스트용 시작시간 설정?
 
             EventSchedule eventSchedule =
                     EventSchedule.builder()
@@ -407,9 +407,8 @@ class ExhibitionControllerTest {
 
         ExhibitionSearchDTO exhibitionSearchDTO =
                 ExhibitionSearchDTO.builder()
-                        .startDateTime(LocalDateTime.now())
-                        .endDateTime(LocalDateTime.now().plusMonths(1))
-                        .eventType(EventType.STANDARD.name())
+                        .startDate(LocalDate.now())
+                        .endDate(LocalDate.now().plusMonths(3))
                         .build();
 
         int page = 0;
@@ -419,9 +418,9 @@ class ExhibitionControllerTest {
         mockMvc
                 .perform(
                         get("/api/exhibitions")
-                                .param("startDate", exhibitionSearchDTO.getStartDateTime().toString())
-                                .param("endDate", exhibitionSearchDTO.getEndDateTime().toString())
-                                .param("eventType", exhibitionSearchDTO.getEventType())
+                                .param("startDate", exhibitionSearchDTO.getStartDate().toString())
+                                .param("endDate", exhibitionSearchDTO.getEndDate().toString())
+                                .param("eventType", "ALL")
                                 .param("page", String.valueOf(page))
                                 .param("size", String.valueOf(size))
                                 .param("sortDirection", sortDirection))
@@ -510,8 +509,8 @@ class ExhibitionControllerTest {
 
         ExhibitionSearchDTO exhibitionSearchDTO =
                 ExhibitionSearchDTO.builder()
-                        .startDateTime(LocalDateTime.now().minusWeeks(1))
-                        .endDateTime(LocalDateTime.now().plusMonths(1))
+                        .startDate(LocalDate.now().minusWeeks(1))
+                        .endDate(LocalDate.now().plusMonths(1))
                         .eventType(SearchEventType.ALL.name())
                         .build();
 
@@ -522,8 +521,8 @@ class ExhibitionControllerTest {
         mockMvc
                 .perform(
                         get("/api/exhibitions")
-                                .param("startDate", exhibitionSearchDTO.getStartDateTime().toString())
-                                .param("endDate", exhibitionSearchDTO.getEndDateTime().toString())
+                                .param("startDate", exhibitionSearchDTO.getStartDate().toString())
+                                .param("endDate", exhibitionSearchDTO.getEndDate().toString())
                                 .param("eventType", exhibitionSearchDTO.getEventType())
                                 .param("page", String.valueOf(page))
                                 .param("size", String.valueOf(size))
@@ -541,8 +540,8 @@ class ExhibitionControllerTest {
 
         ExhibitionSearchDTO exhibitionSearchDTO =
                 ExhibitionSearchDTO.builder()
-                        .startDateTime(LocalDateTime.now().plusDays(1))
-                        .endDateTime(LocalDateTime.now())
+                        .startDate(LocalDate.now().plusDays(1))
+                        .endDate(LocalDate.now())
                         .eventType(EventType.STANDARD.name())
                         .build();
         int page = 0;
@@ -552,8 +551,8 @@ class ExhibitionControllerTest {
         mockMvc
                 .perform(
                         get("/api/exhibitions")
-                                .param("startDateTime", exhibitionSearchDTO.getStartDateTime().toString())
-                                .param("endDateTime", exhibitionSearchDTO.getEndDateTime().toString())
+                                .param("startDate", exhibitionSearchDTO.getStartDate().toString())
+                                .param("endDate", exhibitionSearchDTO.getEndDate().toString())
                                 .param("eventType", exhibitionSearchDTO.getEventType())
                                 .param("page", String.valueOf(page))
                                 .param("size", String.valueOf(size))

--- a/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import jakarta.transaction.Transactional;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -191,7 +192,9 @@ class ExhibitionControllerTest {
         locationRepository.save(location);
 
         for (int i = 0; i < scheduleSize; i++) {
-            LocalDateTime defaultStartDateTime = LocalDateTime.now(); // TODO : 테스트용 시작시간 설정?
+            LocalDateTime defaultStartDateTime = LocalDateTime.now()
+                    .withSecond(0)
+                    .withNano(0);
 
             EventSchedule eventSchedule =
                     EventSchedule.builder()

--- a/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
+++ b/src/test/java/com/example/codebase/controller/ExhibitionControllerTest.java
@@ -196,6 +196,8 @@ class ExhibitionControllerTest {
                     .withSecond(0)
                     .withNano(0);
 
+            long time = System.currentTimeMillis();
+
             EventSchedule eventSchedule =
                     EventSchedule.builder()
                             .startDateTime(defaultStartDateTime.plusDays(i))
@@ -271,7 +273,7 @@ class ExhibitionControllerTest {
 
     private byte[] createImageFile() throws IOException {
         File file =
-                resourceLoader.getResource("classpath:test/img.jpg").getFile(); // TODO : 테스트용 이미지 파일
+                resourceLoader.getResource("classpath:test/img.jpg").getFile();
         return Files.readAllBytes(file.toPath());
     }
 


### PR DESCRIPTION
- Exhibition이 time으로 변경됨에 따라 조회가 제대로 안되던 문제를 해결했습니다.
- test코드에서 고정된 eventSchedule값을 현재시간을 기준으로 하도록 수정했습니다. (00초로 설정합니다)
- Exhibition 상세조회시 작성자의 프로필,정보가 반환됩니다.
- ExhibitionParticipant이 제대로 입력, 반환이 안되던 문제를 해결했습니다.